### PR TITLE
support sync columns and create table without specify columns

### DIFF
--- a/src/main/java/io/druid/hyper/hive/io/Constants.java
+++ b/src/main/java/io/druid/hyper/hive/io/Constants.java
@@ -1,24 +1,13 @@
 package io.druid.hyper.hive.io;
 
 public class Constants {
-    /* Constants for LLAP */
-    public static final String LLAP_LOGGER_NAME_QUERY_ROUTING = "query-routing";
-    public static final String LLAP_LOGGER_NAME_CONSOLE = "console";
-    public static final String LLAP_LOGGER_NAME_RFA = "RFA";
-
     /* Constants for Druid storage handler */
     public static final String DRUID_HIVE_STORAGE_HANDLER_ID =
-            "org.apache.hadoop.hive.druid.DruidStorageHandler";
-    public static final String DRUID_HIVE_OUTPUT_FORMAT =
-            "org.apache.hadoop.hive.druid.io.DruidOutputFormat";
+            "io.druid.hyper.hive.DruidStorageHandler";
     public static final String DRUID_DATA_SOURCE = "druid.datasource";
     public static final String HIVE_DRUID_HMASTER_DEFAULT_ADDRESS = "druid.hmaster.address.default";
-    public static final String DRUID_SEGMENT_GRANULARITY = "druid.segment.granularity";
-    public static final String DRUID_TIMESTAMP_GRANULARITY_COL_NAME = "__time_granularity";
-    public static final String DRUID_QUERY_JSON = "druid.query.json";
-    public static final String DRUID_QUERY_TYPE = "druid.query.type";
-    public static final String DRUID_QUERY_FETCH = "druid.query.fetch";
-    public static final String DRUID_SEGMENT_DIRECTORY = "druid.storage.storageDirectory";
     public static final String DRUID_SEGMENT_VERSION = "druid.segment.version";
-    public static final String DRUID_JOB_WORKING_DIRECTORY = "druid.job.workingDirectory";
+
+    public static final String TIME_COLUMN_NAME = "__time";
+
 }

--- a/src/main/java/io/druid/hyper/hive/serde/DruidSerDe.java
+++ b/src/main/java/io/druid/hyper/hive/serde/DruidSerDe.java
@@ -23,6 +23,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
+import io.druid.hyper.client.util.HMasterUtil;
 import io.druid.hyper.client.util.HttpClientUtil;
 import io.druid.hyper.hive.io.Constants;
 import javafx.util.Pair;
@@ -245,7 +246,7 @@ public class DruidSerDe extends AbstractSerDe {
     try {
 
       String response = HttpClientUtil.get(
-          String.format("%s/druid/hmaster/v1/datasources/dimensions/%s", "http://" + address, dataSource));
+          String.format("%s/druid/hmaster/v1/datasources/dimensions/%s", "http://" + HMasterUtil.getLeader(StringUtils.split(address,",")), dataSource));
 
       Map<String, Object> segmentAnalysisList = objectMapper.readValue(
           response,

--- a/src/main/java/io/druid/hyper/hive/serde/DruidSerDeUtils.java
+++ b/src/main/java/io/druid/hyper/hive/serde/DruidSerDeUtils.java
@@ -36,15 +36,23 @@ public final class DruidSerDeUtils {
 
   protected static final String STRING_TYPE = "STRING";
 
+  protected static final String INT_TYPE = "INT";
+
+  protected static final String DOUBLE_TYPE = "DOUBLE";
+
   /* This method converts from the String representation of Druid type
    * to the corresponding Hive type */
   public static PrimitiveTypeInfo convertDruidToHiveType(String typeName) {
     typeName = typeName.toUpperCase();
     switch (typeName) {
+      case INT_TYPE:
+        return TypeInfoFactory.intTypeInfo;
       case FLOAT_TYPE:
         return TypeInfoFactory.floatTypeInfo;
       case LONG_TYPE:
         return TypeInfoFactory.longTypeInfo;
+      case DOUBLE_TYPE:
+        return TypeInfoFactory.doubleTypeInfo;
       case STRING_TYPE:
         return TypeInfoFactory.stringTypeInfo;
       default:

--- a/src/main/java/io/druid/hyper/hive/serde/TableInfo.java
+++ b/src/main/java/io/druid/hyper/hive/serde/TableInfo.java
@@ -1,0 +1,95 @@
+package io.druid.hyper.hive.serde;
+
+import io.druid.hyper.hive.io.Constants;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TableInfo {
+  public static final String COLUMN_TYPES_SPLIT = ":";
+
+  private final List<String> columnNames = new ArrayList<>();
+  private final List<PrimitiveTypeInfo> columnTypes = new ArrayList<>();
+  private final List<String> comments = new ArrayList<>();
+  private final Map<String, PrimitiveTypeInfo> columnTypeMap = new HashMap<>();
+  private final List<ObjectInspector> inspectors = new ArrayList<>();
+  private boolean timestampAdded = false;
+
+  public TableInfo() {
+    // Timestamp column
+    addColumn(Constants.TIME_COLUMN_NAME, TypeInfoFactory.timestampTypeInfo);
+    timestampAdded = true;
+  }
+
+  public boolean containColumn(String column) {
+    return columnNames.contains(column);
+  }
+
+  public PrimitiveTypeInfo getColumnType(String columnName) {
+    PrimitiveTypeInfo type = columnTypeMap.get(columnName.toLowerCase());
+    if (type != null) {
+      return type;
+    }
+    return TypeInfoFactory.stringTypeInfo;
+  }
+
+  public PrimitiveTypeInfo[] getColumnTypes() {
+    return columnTypes.toArray(new PrimitiveTypeInfo[columnTypes.size()]);
+  }
+
+  public List<String> getColumnNames() {
+    return columnNames;
+  }
+
+  public List<ObjectInspector> getInspectors() {
+    return inspectors;
+  }
+
+  public List<String> getComments() {
+    return comments;
+  }
+
+
+  public String[] getColumnArray() {
+    return columnNames.toArray(new String[columnNames.size()]);
+  }
+
+  public void addColumn(String col) {
+    String[] tmp = col.split(COLUMN_TYPES_SPLIT);
+    PrimitiveTypeInfo type = TypeInfoFactory.getPrimitiveTypeInfo(tmp[1]);
+    addColumn(tmp[0], type, col);
+  }
+
+  public void addColumn(String col, String typeName) {
+    PrimitiveTypeInfo type = DruidSerDeUtils.convertDruidToHiveType(typeName);
+    addColumn(col, type);
+  }
+
+  public void addColumn(String col, PrimitiveTypeInfo type) {
+    addColumn(col, type, col + COLUMN_TYPES_SPLIT + type.getTypeName());
+  }
+
+  public void addColumn(String col, PrimitiveTypeInfo type, String comment) {
+    if (Constants.TIME_COLUMN_NAME.equals(col) && timestampAdded) {
+      return;
+    }
+    columnNames.add(col);
+    columnTypes.add(type);
+    comments.add(comment);
+    columnTypeMap.put(col.toLowerCase(), type);
+    inspectors.add(PrimitiveObjectInspectorFactory.getPrimitiveWritableObjectInspector(type));
+  }
+
+  @Override public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("columns:").append(columnNames);
+    builder.append(", types:").append(columnTypes);
+    return builder.toString();
+  }
+}


### PR DESCRIPTION
1.支持创建表不指定列，直接使用uindex字段，并支持字段同步更新,包括字段名称和类型
2.支持指定多个hmaster
3.hive表数据类型增加int , double
4.多值类型映射成hive array类型